### PR TITLE
use DBL_EPSILON instead of DOUBLE_EPS to support STRICT_R_HEADERS

### DIFF
--- a/src/GIG_helper.cpp
+++ b/src/GIG_helper.cpp
@@ -333,7 +333,7 @@ double rgig(double lambda, double chi, double psi){
   
   // allocate array for random sample //
   
-  if (chi < DOUBLE_EPS*10.0) { 
+  if (chi < DBL_EPSILON*10.0) { 
     // special cases which are basically Gamma and Inverse Gamma distribution //
     if (lambda > 0.0) {
       res = R::rgamma(lambda, 2.0/psi); 
@@ -343,7 +343,7 @@ double rgig(double lambda, double chi, double psi){
     }    
   }
   
-  else if (psi < DOUBLE_EPS*10.0) {
+  else if (psi < DBL_EPSILON*10.0) {
     // special cases which are basically Gamma and Inverse Gamma distribution //
     if (lambda > 0.0) {
       res = 1.0/R::rgamma(lambda, 2.0/chi); 


### PR DESCRIPTION
Dear Yunyi Shen, Dear CARlasso team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in one file, twice) DOUBLE_EPS but when STRICT_R_HEADERS is in use the equivalent DBL_EPSILON is preferred. You can set STRICT_R_HEADERS as a `#define` in a header or source file, via `-DSTRICT_R_HEADERS` as a compiler flag, or as a `#define` in the Rcpp sources as we currently do for testing. We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

Of course, you can probably also switch to std::numeric_limits<double>::epsilon()) or, as an RcppArmadillo user, to `arma::datum::eps`.

This very simple PR changes one DOUBLE_EPS to DBL_EPSILON. Your code will then work with and without STRICT_R_HEADERS as we now include `cfloat` as a header. To be really safe against older Rcpp release you may want to include it to (or the equivalent float.h). In your case, might be easiest in one common header that defines the tolerance constant.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely monthly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.